### PR TITLE
fix-flaky

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,10 +57,10 @@ updates:
       - dependency-name: "org.eclipse.jetty:*"
         update-types: [ "version-update:semver-major" ]
 
-  # Dependencies for Maven - on 1.12.x
+  # Dependencies for Maven - on 1.13.x
   - package-ecosystem: 'maven'
     directory: '/'
-    target-branch: '1.12.x'
+    target-branch: '1.13.x'
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 50
@@ -102,10 +102,10 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 10
 
-  # Dependencies for GitHub Actions - on 1.12.x
+  # Dependencies for GitHub Actions - on 1.13.x
   - package-ecosystem: 'github-actions'
     directory: '/'
-    target-branch: '1.12.x'
+    target-branch: '1.13.x'
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Cache local Maven repository
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@483ef80eb98fb506c348f7d62e28055e49fe2398 #tag=2.3.0
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 #tag=2.3.1
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,7 +42,7 @@ jobs:
     
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v3.0.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v3.0.0
         with:
           persist-credentials: false
 

--- a/integration-tests/jaxrs/tests/pom.xml
+++ b/integration-tests/jaxrs/tests/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.2</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/integration-tests/jaxrs/tests/pom.xml
+++ b/integration-tests/jaxrs/tests/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
+            <version>2.3.9</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1847,24 +1847,4 @@
             </build>
         </profile>
     </profiles>
-    <!--Disable snapshot repositories because they download snapshots
-        instead of using the current build in CI 'mvn verify' steps-->
-    <repositories>
-        <repository>
-            <id>apache.snapshots</id>
-            <url>https://repository.apache.org/snapshots</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>apache.snapshots</id>
-            <url>https://repository.apache.org/snapshots</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
              modules' OSGi metadata: -->
         <ehcache.version>2.6.11</ehcache.version>
         <!-- Don't change this version without also changing the shiro-hazelcast and shiro-features OSGi metadata: -->
-        <hazelcast.version>5.3.4</hazelcast.version>
+        <hazelcast.version>5.3.5</hazelcast.version>
         <hsqldb.version>2.7.2</hsqldb.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jcache.api.version>1.1.1</jcache.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1847,4 +1847,24 @@
             </build>
         </profile>
     </profiles>
+    <!--Disable snapshot repositories because they download snapshots
+        instead of using the current build in CI 'mvn verify' steps-->
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
              modules' OSGi metadata: -->
         <ehcache.version>2.6.11</ehcache.version>
         <!-- Don't change this version without also changing the shiro-hazelcast and shiro-features OSGi metadata: -->
-        <hazelcast.version>5.3.2</hazelcast.version>
+        <hazelcast.version>5.3.4</hazelcast.version>
         <hsqldb.version>2.7.2</hsqldb.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jcache.api.version>1.1.1</jcache.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
              modules' OSGi metadata: -->
         <aspectj.version>1.9.20.1</aspectj.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
-        <commons.cli.version>1.5.0</commons.cli.version>
+        <commons.cli.version>1.6.0</commons.cli.version>
         <commons.codec.version>1.14</commons.codec.version>
         <commons.collection.version>3.2.2</commons.collection.version>
         <commons.configuration2.version>2.9.0</commons.configuration2.version>
@@ -109,7 +109,7 @@
              modules' OSGi metadata: -->
         <quartz.version>2.3.2</quartz.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <log4j.version>2.20.0</log4j.version>
+        <log4j.version>2.21.1</log4j.version>
         <spring.version>5.3.30</spring.version>
         <spring-boot.version>2.7.17</spring-boot.version>
         <guice.version>4.2.3</guice.version>
@@ -303,7 +303,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -538,7 +538,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <configLocation>${checkstyle.configLocation}</configLocation>
                         <suppressionsLocation>${checkstyle.supressionsLocation}</suppressionsLocation>
@@ -1522,7 +1522,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1626,12 +1626,6 @@
                         </reports>
                     </reportSet>
                 </reportSets>
-
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>dashboard-maven-plugin</artifactId>
-                <version>1.0.0-beta-1</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.11</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
     </distributionManagement>
 
     <properties>
-
-        <shiro.previousVersion>1.7.1</shiro.previousVersion>
+        <shiro.previousVersion>1.13.0</shiro.previousVersion>
         <!-- Replaced by the build number plugin at build time: -->
         <buildNumber>${user.name}-${maven.build.timestamp}</buildNumber>
         <project.build.outputTimestamp>2022-03-22T23:08:15Z</project.build.outputTimestamp>
@@ -77,6 +76,7 @@
         <!--suppress CheckTagEmptyBody -->
         <failsafe.argLine></failsafe.argLine>
         <nexus.deploy.skip>false</nexus.deploy.skip>
+        <nexus-staging-profile>nexus-staging</nexus-staging-profile>
         <jacocoAgent/>
         <!-- non-dependency-based properties: -->
         <shiro.osgi.importRange>[2, 3)</shiro.osgi.importRange>
@@ -783,23 +783,18 @@
                     <pushChanges>false</pushChanges>
                     <localCheckout>true</localCheckout>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <!-- This configuration copied from apache:apache:7 parent pom -->
-                    <useReleaseProfile>false</useReleaseProfile>
                     <preparationGoals>validate</preparationGoals>
+                    <preparationProfiles>skip-checkstyle</preparationProfiles>
                     <goals>deploy</goals>
-                    <arguments>-Pdocs,apache-release,skip-checkstyle</arguments>
+                    <releaseProfiles>docs,apache-release,${nexus-staging-profile}</releaseProfiles>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <extensions>true</extensions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <nexusUrl>https://repository.apache.org</nexusUrl>
-                    <serverId>apache.releases.https</serverId>
-                    <skipNexusStagingDeployMojo>${nexus.deploy.skip}</skipNexusStagingDeployMojo>
+                    <deployAtEnd>true</deployAtEnd>
                 </configuration>
             </plugin>
             <plugin>
@@ -1755,6 +1750,24 @@
             </build>
         </profile>
         <profile>
+            <id>nexus-staging</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://repository.apache.org</nexusUrl>
+                            <serverId>apache.releases.https</serverId>
+                            <skipNexusStagingDeployMojo>${nexus.deploy.skip}</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <!--  NOTE: this plugin config will return false positives, usage will require
                   human interpretation (and should NOT be used to fail builds)
             -->
@@ -1855,6 +1868,9 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -1864,6 +1880,9 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.20.0</log4j.version>
         <spring.version>5.3.30</spring.version>
-        <spring-boot.version>2.7.16</spring-boot.version>
+        <spring-boot.version>2.7.17</spring-boot.version>
         <guice.version>4.2.3</guice.version>
         <jaxrs.api.version>2.1.6</jaxrs.api.version>
         <htmlunit.version>3.6.0</htmlunit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <commons.cli.version>1.6.0</commons.cli.version>
         <commons.collection.version>3.2.2</commons.collection.version>
         <commons.configuration2.version>2.9.0</commons.configuration2.version>
-        <commons.lang3.version>3.12.0</commons.lang3.version>
+        <commons.lang3.version>3.13.0</commons.lang3.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.text.version>1.8</commons.text.version>
         <!-- Don't change this version without also changing the shiro-ehcache and shiro-features

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
         <aspectj.version>1.9.20.1</aspectj.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.cli.version>1.6.0</commons.cli.version>
-        <commons.codec.version>1.14</commons.codec.version>
         <commons.collection.version>3.2.2</commons.collection.version>
         <commons.configuration2.version>2.9.0</commons.configuration2.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.18.1</version>
+                    <version>0.18.2</version>
                     <configuration>
                         <oldVersion>
                             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>8.4.0</version>
+                    <version>8.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jcache.api.version>1.1.1</jcache.api.version>
         <jdk.version>11</jdk.version>
-        <jetty.version>9.4.52.v20230823</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <owasp.java.encoder.version>1.2.3</owasp.java.encoder.version>
         <!-- Don't change this version without also changing the shiro-quartz and shiro-features
              modules' OSGi metadata: -->

--- a/samples/spring-boot-3-web/pom.xml
+++ b/samples/spring-boot-3-web/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <module.name>samples.spring.boot3.web</module.name>
-        <spring-boot3.version>3.1.2</spring-boot3.version>
+        <spring-boot3.version>3.1.5</spring-boot3.version>
         <!--    below versions are not necessary in "real" applications -->
-        <spring.version>6.0.11</spring.version>
+        <spring.version>6.0.13</spring.version>
     </properties>
 
     <dependencies>

--- a/samples/spring-boot-3-web/pom.xml
+++ b/samples/spring-boot-3-web/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <module.name>samples.spring.boot3.web</module.name>
         <spring-boot3.version>3.1.2</spring-boot3.version>
-        <spring-boot.version>2.7.17</spring-boot.version>
         <!--    below versions are not necessary in "real" applications -->
         <spring.version>6.0.11</spring.version>
     </properties>
@@ -93,7 +92,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
+                <version>${spring-boot3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,7 +111,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
+                <version>${spring-boot3.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/samples/spring-boot-3-web/pom.xml
+++ b/samples/spring-boot-3-web/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <module.name>samples.spring.boot3.web</module.name>
         <spring-boot3.version>3.1.2</spring-boot3.version>
-        <spring-boot.version>${spring-boot3.version}</spring-boot.version>
+        <spring-boot.version>2.7.17</spring-boot.version>
         <!--    below versions are not necessary in "real" applications -->
         <spring.version>6.0.11</spring.version>
     </properties>

--- a/samples/web-jakarta/pom.xml
+++ b/samples/web-jakarta/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <meecrowave.version>1.2.15</meecrowave.version>
-        <tomcat.version>10.1.8</tomcat.version>
+        <tomcat.version>10.1.15</tomcat.version>
         <jacoco.skip>true</jacoco.skip>
     </properties>
 
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>default-war</id>

--- a/samples/web-jakarta/src/test/java/org/apache/shiro/test/web/jakarta/WebContainerIT.java
+++ b/samples/web-jakarta/src/test/java/org/apache/shiro/test/web/jakarta/WebContainerIT.java
@@ -31,7 +31,7 @@ import java.net.URI;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static jakarta.ws.rs.core.MediaType.TEXT_HTML_TYPE;
 
-public class WebContainerTest extends JakartaAbstractContainerIT {
+public class WebContainerIT extends JakartaAbstractContainerIT {
 
     @SuppressWarnings("checkstyle:MagicNumber")
     @Test

--- a/support/features/pom.xml
+++ b/support/features/pom.xml
@@ -40,7 +40,7 @@
         <!-- Not a Shiro dependency - used for quartz bundle resolution only (see features.xml): -->
         <commons.collections.version>3.2.2</commons.collections.version>
         <!-- karaf plugin version -->
-        <karaf.version>4.4.3</karaf.version>
+        <karaf.version>4.4.4</karaf.version>
     </properties>
 
     <dependencies>

--- a/support/jakarta-ee/pom.xml
+++ b/support/jakarta-ee/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.16.1</version>
+            <version>1.16.2</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/support/jaxrs/pom.xml
+++ b/support/jaxrs/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/tools/hasher/pom.xml
+++ b/tools/hasher/pom.xml
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.7.16</version>
+                <version>2.7.17</version>
                 <executions>
                     <execution>
                         <goals>

--- a/web/src/main/java/org/apache/shiro/web/filter/InvalidRequestFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/InvalidRequestFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 @SuppressWarnings("checkstyle:LineLength")
 /**
@@ -65,6 +66,12 @@ public class InvalidRequestFilter extends AccessControlFilter {
 
     private boolean blockTraversal = true;
 
+    private boolean blockEncodedPeriod = true;
+
+    private boolean blockEncodedForwardSlash = true;
+
+    private boolean blockRewriteTraversal = true;
+
     @Override
     protected boolean isAccessAllowed(ServletRequest req, ServletResponse response, Object mappedValue) throws Exception {
         HttpServletRequest request = WebUtils.toHttp(req);
@@ -77,12 +84,15 @@ public class InvalidRequestFilter extends AccessControlFilter {
                 && isValid(request.getPathInfo());
     }
 
+    @SuppressWarnings("checkstyle:BooleanExpressionComplexity")
     private boolean isValid(String uri) {
         return !StringUtils.hasText(uri)
-                || (!containsSemicolon(uri)
-                && !containsBackslash(uri)
-                && !containsNonAsciiCharacters(uri))
-                && !containsTraversal(uri);
+               || (!containsSemicolon(uri)
+                 && !containsBackslash(uri)
+                 && !containsNonAsciiCharacters(uri)
+                 && !containsTraversal(uri)
+                 && !containsEncodedPeriods(uri)
+                 && !containsEncodedForwardSlash(uri));
     }
 
     @Override
@@ -125,9 +135,22 @@ public class InvalidRequestFilter extends AccessControlFilter {
 
     private boolean containsTraversal(String uri) {
         if (isBlockTraversal()) {
-            return !(isNormalized(uri)
-                    && PERIOD.stream().noneMatch(uri::contains)
-                    && FORWARDSLASH.stream().noneMatch(uri::contains));
+            return !isNormalized(uri)
+                || (isBlockRewriteTraversal() && Stream.of("/..;", "/.;").anyMatch(uri::contains));
+        }
+        return false;
+    }
+
+    private boolean containsEncodedPeriods(String uri) {
+        if (isBlockEncodedPeriod()) {
+            return PERIOD.stream().anyMatch(uri::contains);
+        }
+        return false;
+    }
+
+    private boolean containsEncodedForwardSlash(String uri) {
+        if (isBlockEncodedForwardSlash()) {
+            return FORWARDSLASH.stream().anyMatch(uri::contains);
         }
         return false;
     }
@@ -188,5 +211,29 @@ public class InvalidRequestFilter extends AccessControlFilter {
 
     public void setBlockTraversal(boolean blockTraversal) {
         this.blockTraversal = blockTraversal;
+    }
+
+    public boolean isBlockEncodedPeriod() {
+        return blockEncodedPeriod;
+    }
+
+    public void setBlockEncodedPeriod(boolean blockEncodedPeriod) {
+        this.blockEncodedPeriod = blockEncodedPeriod;
+    }
+
+    public boolean isBlockEncodedForwardSlash() {
+        return blockEncodedForwardSlash;
+    }
+
+    public void setBlockEncodedForwardSlash(boolean blockEncodedForwardSlash) {
+        this.blockEncodedForwardSlash = blockEncodedForwardSlash;
+    }
+
+    public boolean isBlockRewriteTraversal() {
+        return blockRewriteTraversal;
+    }
+
+    public void setBlockRewriteTraversal(boolean blockRewriteTraversal) {
+        this.blockRewriteTraversal = blockRewriteTraversal;
     }
 }

--- a/web/src/main/java/org/apache/shiro/web/util/SavedRequest.java
+++ b/web/src/main/java/org/apache/shiro/web/util/SavedRequest.java
@@ -60,6 +60,12 @@ public class SavedRequest implements Serializable {
 
     public String getRequestUrl() {
         StringBuilder requestUrl = new StringBuilder(getRequestURI());
+
+        // remove duplicate leading slashes
+        while (requestUrl.length() > 1 && requestUrl.charAt(1) == '/') {
+            requestUrl.deleteCharAt(0);
+        }
+
         if (getQueryString() != null) {
             requestUrl.append("?").append(getQueryString());
         }

--- a/web/src/test/groovy/org/apache/shiro/web/filter/InvalidRequestFilterTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/filter/InvalidRequestFilterTest.groovy
@@ -38,6 +38,9 @@ class InvalidRequestFilterTest {
         assertThat "filter.blockNonAscii expected to be true", filter.isBlockNonAscii()
         assertThat "filter.blockSemicolon expected to be true", filter.isBlockSemicolon()
         assertThat "filter.blockTraversal expected to be true", filter.isBlockTraversal()
+        assertThat "filter.blockRewriteTraversal expected to be true", filter.isBlockRewriteTraversal()
+        assertThat "filter.blockEncodedPeriod expected to be true", filter.isBlockEncodedPeriod()
+        assertThat "filter.blockEncodedForwardSlash expected to be true", filter.isBlockEncodedForwardSlash()
     }
 
     @Test
@@ -58,7 +61,6 @@ class InvalidRequestFilterTest {
         }
     }
 
-
     @Test
     void testFilterBlocks() {
         InvalidRequestFilter filter = new InvalidRequestFilter()
@@ -72,6 +74,7 @@ class InvalidRequestFilterTest {
 
         assertPathBlocked(filter, "/something", "/;something")
         assertPathBlocked(filter, "/something", "/something", "/;")
+        assertPathBlocked(filter, "/something", "/something", "/.;")
     }
 
     @Test
@@ -80,23 +83,81 @@ class InvalidRequestFilterTest {
         assertPathBlocked(filter, "/something/../")
         assertPathBlocked(filter, "/something/../bar")
         assertPathBlocked(filter, "/something/../bar/")
-        assertPathBlocked(filter, "/something/%2e%2E/bar/")
         assertPathBlocked(filter, "/something/..")
         assertPathBlocked(filter, "/..")
         assertPathBlocked(filter, "..")
         assertPathBlocked(filter, "../")
-        assertPathBlocked(filter, "%2E./")
         assertPathBlocked(filter, "%2F./")
         assertPathBlocked(filter, "/something/./")
         assertPathBlocked(filter, "/something/./bar")
         assertPathBlocked(filter, "/something/\u002e/bar")
         assertPathBlocked(filter, "/something/./bar/")
-        assertPathBlocked(filter, "/something/%2e/bar/")
-        assertPathBlocked(filter, "/something/%2f/bar/")
         assertPathBlocked(filter, "/something/.")
         assertPathBlocked(filter, "/.")
         assertPathBlocked(filter, "/something/../something/.")
         assertPathBlocked(filter, "/something/../something/.")
+        assertPathBlocked(filter, "/something/.;")
+        assertPathBlocked(filter, "/something/%2e%3b")
+
+        assertPathAllowed(filter, "/something/.bar")
+        assertPathAllowed(filter, "/.something")
+        assertPathAllowed(filter, ".something")
+    }
+
+    @Test
+    void testBlocksEncodedPeriod() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        assertPathBlocked(filter, "/%2esomething")
+        assertPathBlocked(filter, "%2esomething")
+        assertPathBlocked(filter, "%2E./")
+        assertPathBlocked(filter, "%2F./")
+        assertPathBlocked(filter, "/something/%2e;")
+        assertPathBlocked(filter, "/something/%2e%3b")
+        assertPathBlocked(filter, "/something/%2e%2E/bar/")
+        assertPathBlocked(filter, "/something/%2e/bar/")
+    }
+
+    @Test
+    void testAllowsEncodedPeriod() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        filter.setBlockEncodedPeriod(false)
+        assertPathAllowed(filter, "/%2esomething")
+        assertPathAllowed(filter, "%2esomething")
+        assertPathAllowed(filter, "%2E./")
+        assertPathAllowed(filter, "/something/%2e%2E/bar/")
+        assertPathAllowed(filter, "/something/%2e/bar/")
+    }
+
+    @Test
+    void testBlocksEncodedForwardSlash() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        assertPathBlocked(filter, "%2F./")
+        assertPathBlocked(filter, "/something/%2f/bar/")
+    }
+
+    @Test
+    void testAllowsEncodedForwardSlash() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        filter.setBlockEncodedForwardSlash(false)
+        assertPathAllowed(filter, "%2F./")
+        assertPathAllowed(filter, "/something/%2f/bar/")
+    }
+
+    @Test
+    void testBlocksRewriteTraversal() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        filter.setBlockSemicolon(false)
+        assertPathBlocked(filter, "/something/..;jsessionid=foobar")
+        assertPathBlocked(filter, "/something/.;jsessionid=foobar")
+    }
+
+    @Test
+    void testAllowRewriteTraversal() {
+        InvalidRequestFilter filter = new InvalidRequestFilter()
+        filter.setBlockSemicolon(false)
+        filter.setBlockRewriteTraversal(false)
+        assertPathAllowed(filter, "/something/..;jsessionid=foobar")
+        assertPathAllowed(filter, "/something/.;jsessionid=foobar")
     }
 
     @Test
@@ -159,15 +220,11 @@ class InvalidRequestFilterTest {
         assertPathAllowed(filter, "/..")
         assertPathAllowed(filter, "..")
         assertPathAllowed(filter, "../")
-        assertPathAllowed(filter, "%2E./")
-        assertPathAllowed(filter, "%2F./")
         assertPathAllowed(filter, "/something/./")
         assertPathAllowed(filter, "/something/./bar")
         assertPathAllowed(filter, "/something/\u002e/bar")
         assertPathAllowed(filter, "/something\u002fbar")
         assertPathAllowed(filter, "/something/./bar/")
-        assertPathAllowed(filter, "/something/%2e/bar/")
-        assertPathAllowed(filter, "/something/%2f/bar/")
         assertPathAllowed(filter, "/something/.")
         assertPathAllowed(filter, "/.")
         assertPathAllowed(filter, "/something/../something/.")

--- a/web/src/test/groovy/org/apache/shiro/web/util/SavedRequestTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/util/SavedRequestTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.web.util
+
+import org.junit.jupiter.api.Test
+
+import javax.servlet.http.HttpServletRequest
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
+import static org.easymock.EasyMock.niceMock
+import static org.easymock.EasyMock.expect
+import static org.easymock.EasyMock.replay
+import static org.easymock.EasyMock.verify
+
+class SavedRequestTest {
+
+    @Test
+    void testGetRequestUrl() {
+        doTestGetRequestUrl("/foo//bar", "one=two&three=four", "/foo//bar?one=two&three=four")
+        doTestGetRequestUrl("///foo//bar", "one=two&three=four", "/foo//bar?one=two&three=four")
+        doTestGetRequestUrl("///foo//bar", "/foo//bar")
+        doTestGetRequestUrl("/foo", "/foo")
+        doTestGetRequestUrl("/", "one=two&three=four", "/?one=two&three=four")
+        doTestGetRequestUrl("/", "/")
+        doTestGetRequestUrl("//////", "/")
+        doTestGetRequestUrl("", "")
+    }
+
+    private static void doTestGetRequestUrl(String requestURI, String expected) {
+        doTestGetRequestUrl(requestURI, null, expected)
+    }
+
+    private static void doTestGetRequestUrl(String requestURI, String query, String expected) {
+        HttpServletRequest request = niceMock(HttpServletRequest)
+        expect(request.getRequestURI()).andReturn(requestURI)
+        expect(request.getQueryString()).andReturn(query)
+        replay request
+        assertThat new SavedRequest(request).getRequestUrl(), equalTo(expected)
+        verify request
+    }
+}


### PR DESCRIPTION
### Flakiness
**Nondex** was used to check and locate the flakiness in the test. The test can be reproduced using the following command:
```shell
mvn install -pl support/cdi -am -DskipTests
mvn -pl support/cdi test -Dtest=org.apache.shiro.cdi.AnnotatedTypeWrapperTest#removeAnnotations
mvn -pl support/cdi edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.shiro.cdi.AnnotatedTypeWrapperTest#removeAnnotations
``` 

### Issue
The test checks that if there is no `Annotation` in the `RequiresGuest` class and there is `Annotation` in `SessionScoped` class. It retrieves these classes by calling `getDeclaredAnnotations` method and fix indexing on the array returned. This creates the problem. Here is the implementation of  `getDeclaredAnnotations` :
```java
public Annotation[] getDeclaredAnnotations() {
     return AnnotationParser.toArray(this.annotationData().declaredAnnotations);
}
// this.annotationData().declaredAnnotationsdeclaredAnnotations is a map
Map<Class<? extends Annotation>, Annotation> declaredAnnotations = ....
```
Since the array is created from a hashmap, the order of elements in the output of `getDeclaredAnnotations` is not determinstic. Therefore, the fix indexing creates flakiness.

## Fix
Since only `SessionScoped`  and `RequiresGuest` are tested, those 2 classes are specificly extracted from the array instead of using indexing. 
